### PR TITLE
CMS Module - Allow multiple joins on back column

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -146,7 +146,20 @@ final class DB {
 
             if (preg_match($regex, $query, $matches)) {
                 $nr_langs_per_column = array(); // for replacing ?:lg with real count of placeholders
-                $languages = (empty($params[':lg']) ? array((($class)::TRANSLATOR)::get()) : NULL);
+
+                $languages = NULL;
+
+                if (empty($params[':lg'])) {
+                    if (($class)::translationTimes() > 0) {
+                        $languages = array((($class)::TRANSLATOR)::get());
+                    }
+                    else {
+                        throw new Exception(
+                            "|ArshWell| ".static::class."::languages() query can't replace :lg placeholders;
+                            Should be send as params or fetched from your class const TRANSLATOR"
+                        );
+                    }
+                }
 
                 $query = preg_replace_callback(
                     $regex,
@@ -284,6 +297,11 @@ final class DB {
                     $query .= " ".$join[0]." JOIN ". self::$tb_prefixes[self::$key] . $join[1]." ON ".preg_replace("/(\w+[.]\w+)/", self::$tb_prefixes[self::$key]."$1", $join[2]);
                 }
             }
+            else if (!empty($sql['joins'])) {
+                foreach ($sql['joins'] as $join) {
+                    $query .= " ".$join['type']." JOIN ". self::$tb_prefixes[self::$key] . $join['table']." ON ".self::prefix($join['on']);
+                }
+            }
 
             if (isset($sql['where'])) {
                 $query .= " WHERE ". self::prefix($sql['where'], true);
@@ -379,6 +397,11 @@ final class DB {
                     $join = $join['join'];
 
                     $query .= " ".$join[0]." JOIN ". self::$tb_prefixes[self::$key] . $join[1]." ON ".self::prefix($join[2]);
+                }
+            }
+            else if (!empty($sql['joins'])) {
+                foreach ($sql['joins'] as $join) {
+                    $query .= " ".$join['type']." JOIN ". self::$tb_prefixes[self::$key] . $join['table']." ON ".self::prefix($join['on']);
                 }
             }
 

--- a/src/Func.php
+++ b/src/Func.php
@@ -94,10 +94,12 @@ final class Func {
                     $value = array_values($value);
                 }
 
-                $result = array_merge($result, self::arrayFlatten($value));
+                // NOTE: array_merge is not good (it doesn't preserve keys)
+                $result = array_replace($result, self::arrayFlatten($value, $preserve_keys));
             }
             else {
-                $result = array_merge($result, array($key => $value));
+                // NOTE: array_merge is not good (it doesn't preserve keys)
+                $result = array_replace($result, array($key => $value));
             }
         }
         return $result;
@@ -139,8 +141,12 @@ final class Func {
         return $array;
     }
 
-    static function isAssoc (array $array): bool {
-        return (array_keys($array) !== range(0, count($array) - 1));
+    static function isAssoc (array $array, bool $check_if_zero_indexed = true): bool {
+        if ($check_if_zero_indexed) {
+            return (array_keys($array) !== range(0, count($array) - 1));
+        }
+
+        return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
 
     static function hasValidJSON (string $file): bool {

--- a/src/Module/HTML/Field.php
+++ b/src/Module/HTML/Field.php
@@ -782,14 +782,35 @@ final class Field {
                         <option value="" selected hidden><?= $config['HTML']['placeholder'] ?: 'Alege...' ?></option>
                     <?php }
 
-                    foreach ($config['HTML']['values'] as $value => $text) { ?>
-                        <option
-                        value="<?= $value ?>"
-                        <?= ($config['HTML']['readonly'] ? 'disabled="disabled"' : '') ?>
-                        <?= (in_array($value, $config['HTML']['value']) ? 'selected' : '') ?>>
-                            <?= $text ?>
-                        </option>
-                    <?php } ?>
+                    // optgroups with options
+                    if (\Arsavinel\Arshwell\Func::isAssoc($config['HTML']['values'], false)) {
+                        foreach ($config['HTML']['values'] as $optgroup_name => $values) { ?>
+                            <optgroup label="<?= $optgroup_name ?>">
+                                <?php
+                                foreach ($values as $value => $text) { ?>
+                                    <option
+                                    value="<?= $value ?>"
+                                    <?= ($config['HTML']['readonly'] ? 'disabled="disabled"' : '') ?>
+                                    <?= (in_array($value, $config['HTML']['value']) ? 'selected' : '') ?>>
+                                        <?= $text ?>
+                                    </option>
+                                <?php } ?>
+                            </optgroup>
+                        <?php }
+                    }
+
+                    // simple options
+                    else {
+                        foreach ($config['HTML']['values'] as $value => $text) { ?>
+                            <option
+                            value="<?= $value ?>"
+                            <?= ($config['HTML']['readonly'] ? 'disabled="disabled"' : '') ?>
+                            <?= (in_array($value, $config['HTML']['value']) ? 'selected' : '') ?>>
+                                <?= $text ?>
+                            </option>
+                        <?php }
+                    } ?>
+
                 </select>
             </div>
             <?php

--- a/src/Module/HTML/Piece.php
+++ b/src/Module/HTML/Piece.php
@@ -7,6 +7,7 @@ use Arsavinel\Arshwell\Table\TableColumn;
 use Arsavinel\Arshwell\Table\TableField;
 use Arsavinel\Arshwell\Text;
 use Arsavinel\Arshwell\File;
+use Arsavinel\Arshwell\Func;
 use Arsavinel\Arshwell\URL;
 use Arsavinel\Arshwell\Web;
 
@@ -192,9 +193,28 @@ final class Piece {
                                 if (in_array($field['HTML']['type'], array('select', 'radio'))) { ?>
                                     <select class="custom-select h-100 d-none" data-key="<?= $key ?>">
                                         <?php
-                                        foreach (($options[$key] ?? $field['HTML']['values'] ?? array()) as $index => $value) { ?>
-                                            <option value="<?= $index ?>"><?= $value ?></option>
-                                        <?php } ?>
+                                        $select = ($options[$key] ?? $field['HTML']['values'] ?? array());
+
+                                        if ($select) {
+                                            // optgroups with options
+                                            if (\Arsavinel\Arshwell\Func::isAssoc($select, false)) {
+                                                foreach ($select as $optgroup_name => $values) { ?>
+                                                    <optgroup label="<?= $optgroup_name ?>">
+                                                        <?php
+                                                        foreach ($values as $index => $value) { ?>
+                                                            <option value="<?= $index ?>"><?= $value ?></option>
+                                                        <?php } ?>
+                                                    </optgroup>
+                                                <?php }
+                                            }
+
+                                            // simple options
+                                            else {
+                                                foreach (($options[$key] ?? $field['HTML']['values'] ?? array()) as $index => $value) { ?>
+                                                    <option value="<?= $index ?>"><?= $value ?></option>
+                                                <?php }
+                                            }
+                                        } ?>
                                     </select>
                                 <?php }
                             } ?>
@@ -216,6 +236,10 @@ final class Piece {
                     }
                     else {
                         foreach ($query['filter'] as $key => $values) {
+                            if (!empty($options[$key]) && Func::isAssoc($options[$key], false)) {
+                                $options[$key] = Func::arrayFlatten($options[$key], true);
+                            }
+
                             foreach ($values as $value) { ?>
                                 <span class="nowrap mr-3" data-field="<?= $key ?>" data-value="<?= $value ?>">
                                     <b><?= $fields[$key]['HTML']['label'] ?>:</b>
@@ -387,6 +411,7 @@ final class Piece {
 
                                             $lg = NULL;
                                             $value = $row[$key];
+                                            $suptitle = NULL;
 
                                             if (is_object($value)) {
                                                 $lg = ($row[$key])->isTranslated() ? ($query['lg'] ?? NULL) : NULL;
@@ -394,6 +419,9 @@ final class Piece {
                                                 switch (get_class($value)) {
                                                     case TableField::class:
                                                     case TableColumn::class: {
+                                                        if (property_exists($value, 'suptitle')) {
+                                                            $suptitle = $value->suptitle;
+                                                        }
                                                         $value = $value->value($lg);
                                                     }
                                                 }
@@ -406,6 +434,13 @@ final class Piece {
                                             }); ?>
 
                                             <td>
+                                                <?php
+                                                if ($suptitle) { ?>
+                                                    <div class="lh-12"><small class="lh-12"><small class="text-muted lh-12">
+                                                        <?= $suptitle ?>
+                                                    </small></small></div>
+                                                <?php } ?>
+
                                                 <?php
                                                 switch ($HTML['type']) {
                                                     case 'image': {

--- a/src/Module/Request/Frontend/Action/Insert.php
+++ b/src/Module/Request/Frontend/Action/Insert.php
@@ -30,7 +30,7 @@ final class Insert {
                             <h6 class="card-header">
                                 Adding
                                 <?php
-                                if (($module['back']['DB']['table'])::isTranslated()) { ?>
+                                if (($module['back']['DB']['table'])::translationTimes() > 1) { ?>
                                     <div style="position: absolute; right: 15px; top: 0;">
                                         <?= Piece::languages(
                                             (($module['back']['DB']['table'])::TRANSLATOR)::LANGUAGES,

--- a/src/Module/Request/Frontend/Action/Select.php
+++ b/src/Module/Request/Frontend/Action/Select.php
@@ -28,10 +28,10 @@ final class Select {
                         ) ?>
                     </div>
 
-                    <div class="col order-1 col-sm-3 order-sm-0 <?= (($module['back']['DB']['table'])::isTranslated() ? 'col-lg-auto' : 'd-lg-none') ?> order-lg-last card">
+                    <div class="col order-1 col-sm-3 order-sm-0 <?= (($module['back']['DB']['table'])::translationTimes() > 1 ? 'col-lg-auto' : 'd-lg-none') ?> order-lg-last card">
                         <div class="card-body text-sm-right py-3">
                             <?php
-                            if (($module['back']['DB']['table'])::isTranslated()) {
+                            if (($module['back']['DB']['table'])::translationTimes() > 1) {
                                 echo Piece::languages((($module['back']['DB']['table'])::TRANSLATOR)::LANGUAGES, $module['query']['lg']);
                             } ?>
                         </div>

--- a/src/Module/Request/Frontend/Feature/Update.php
+++ b/src/Module/Request/Frontend/Feature/Update.php
@@ -33,7 +33,7 @@ final class Update {
                                 <h6 class="card-header">
                                     Editing
                                     <?php
-                                    if (($module['back']['DB']['table'])::isTranslated()) { ?>
+                                    if (($module['back']['DB']['table'])::translationTimes() > 1) { ?>
                                         <div style="position: absolute; right: 15px; top: 0;">
                                             <?= Piece::languages(
                                                 (($module['back']['DB']['table'])::TRANSLATOR)::LANGUAGES,

--- a/src/SQL.php
+++ b/src/SQL.php
@@ -72,4 +72,92 @@ final class SQL {
         }
         return "(SELECT `AUTO_INCREMENT` FROM information_schema.TABLES WHERE `TABLE_SCHEMA` = '". ENV::db('conn.'.$db_key.'.name') ."' AND `TABLE_NAME` = '". ENV::db('conn.'.$db_key.'.prefix'). $table ."')";
     }
+
+    /**
+     * Multiple Joins field To Joins query
+     */
+    static function joinsField2joinsQuery (string $table, string $column, array $joins, &$lgs = array()): array {
+        $suffix = (($table)::translationTimes($column) ? ':lg' : '');
+
+        $query = array(
+            'class' => $table,
+            'columns' => array(
+                ($table)::TABLE .'.'. ($table)::PRIMARY_KEY,
+                ($table)::TABLE .'.'. $column . $suffix .' AS '. ($table)::TABLE .'_'. $column
+            ),
+            'joins' => array(),
+            'order' => array(
+                ($table)::TABLE .'.'. ($table)::PRIMARY_KEY . ' DESC'
+            )
+        );
+
+        foreach ($joins as $join) {
+            if (($join['table'])::translationTimes($join['column']) > 0) {
+                $suffix = ':lg';
+
+                $lgs[($join['table'])::TABLE .'.'. $join['column']] = (($join['table'])::TRANSLATOR)::default();
+            }
+
+            $query['columns'][] = ($join['table'])::TABLE .'.'. ($join['table'])::PRIMARY_KEY;
+            $query['columns'][] = ($join['table'])::TABLE .'.'. $join['column'] . $suffix .' AS '. ($join['table'])::TABLE .'_'. $join['column'];
+
+            $query['order'][] = ($join['table'])::TABLE .'.'. ($join['order'] ?? ($join['table'])::PRIMARY_KEY . ' DESC');
+
+            $query['joins'][] = array(
+                'type'  => "INNER",
+                'table' => ($join['table'])::TABLE,
+                'on'    => ($table)::TABLE .'.'.($join['table'])::PRIMARY_KEY .' = '. ($join['table'])::TABLE .'.'.($join['table'])::PRIMARY_KEY
+            );
+
+            $table = $join['table'];
+        }
+
+        $query['columns'] = implode(', ', $query['columns']);
+        $query['order'] = implode(', ', array_reverse($query['order']));
+
+        return $query;
+    }
+
+    /**
+     * Multiple Tree Joins field To Joins query (recursive method)
+     */
+    static function joinField2joinQuery (array $array, string $table = NULL): array {
+        if (empty($array['table'])) {
+            $array['table'] = $table;
+        }
+
+        $suffix = (($array['table'])::translationTimes($array['column']) ? ':lg' : '');
+
+        $query = array(
+            'columns' => array(
+                ($array['table'])::TABLE .'.'. ($array['table'])::PRIMARY_KEY,
+                ($array['table'])::TABLE .'.'. $array['column'] . $suffix .' AS '. ($array['table'])::TABLE .'_'. $array['column']
+            ),
+            'order' => array(
+                ($array['table'])::TABLE .'.'. ($array['table'])::PRIMARY_KEY . ' DESC'
+            )
+        );
+
+        if (empty($array['join'])) {
+            return $query;
+        }
+        else {
+            $query['joins'] = array(
+                array(
+                    'type'  => "INNER",
+                    'table' => ($array['join']['table'])::TABLE,
+                    'on'    => ($array['table'])::TABLE .'.'.($array['join']['table'])::PRIMARY_KEY .' = '. ($array['join']['table'])::TABLE .'.'.($array['join']['table'])::PRIMARY_KEY
+                )
+            );
+        }
+
+        $query = array_merge_recursive(
+            $query,
+            self::joinField2joinQuery($array['join'])
+        );
+
+        $query['class'] = $array['table'];
+
+        return $query;
+    }
 }

--- a/src/Table/Files/Image.php
+++ b/src/Table/Files/Image.php
@@ -12,6 +12,8 @@ use Arsavinel\Arshwell\ENV;
 
 use Verot\Upload\Upload;
 
+use Exception;
+
 final class Image implements TableSegment {
     private $class;
     private $id_table = NULL;
@@ -107,6 +109,10 @@ final class Image implements TableSegment {
                     $this->smallest[$lg] = $site . ltrim(preg_replace('~^'. ENV::path('uploads', false) .'~', '', $lg_files[Func::keyFromSmallest($lg_sized_files)]), '/');
                     $this->biggest[$lg] = $site . ltrim(preg_replace('~^'. ENV::path('uploads', false) .'~', '', $lg_files[Func::keyFromBiggest($lg_sized_files)]), '/');
                 }
+            }
+
+            if (!defined($this->class .'::TRANSLATOR')) {
+                throw new Exception("|ArshWell| {$this->class} has FILES; so should contain const TRANSLATOR");
             }
 
             foreach ((($this->class)::TRANSLATOR)::LANGUAGES as $language) {

--- a/src/Table/TableFiles.php
+++ b/src/Table/TableFiles.php
@@ -13,20 +13,20 @@ final class TableFiles {
 
     function __construct (string $class, int $id_table = NULL) {
         foreach (($class)::FILES as $filekey => $info) {
-            switch (($info['type'] ?? Table::IMAGE)) {
-                case Table::IMAGE: {
+            switch (($info['type'] ?? Table::FILE_IMAGE)) {
+                case Table::FILE_IMAGE: {
                     $this->files[$filekey] = new Image($class, $id_table, $filekey);
                     break;
                 }
-                case Table::IMAGE_GROUP: {
+                case Table::FILE_IMAGE_GROUP: {
                     $this->files[$filekey] = new ImageGroup($class, $id_table, $filekey);
                     break;
                 }
-                case Table::DOC: {
+                case Table::FILE_DOC: {
                     $this->files[$filekey] = new Doc($class, $id_table, $filekey);
                     break;
                 }
-                case Table::DOC_GROUP: {
+                case Table::FILE_DOC_GROUP: {
                     $this->files[$filekey] = new DocGroup($class, $id_table, $filekey);
                     break;
                 }


### PR DESCRIPTION
Now can be created, a chain of joins, in CMS Module back field.

___

This is the new format allowed:
```
'fields' => array(
    '[key]' => array(
        'DB' => array(
            'column'    => '[column_name]',
            'type'      => '[column_type]',

            'joins'      => array(
                array(
                    'table'     => "[foreign_table_class_1]",
                    'column'    => "[foreign_column_name_1]",
                    'order'     => "[foreign_table_order_rule_1]"
                ),
                array(
                    'table'     => "[foreign_table_class_2]",
                    'column'    => "[foreign_column_name_2]",
                    'order'     => "[foreign_table_order_rule_2]
                )
            )
        ),
        'PHP' => array(
            ...
        )
  )
)
```