### PR TITLE
Bugfix - Func::arrayFlatten() was losing values

### DIFF
--- a/resources/php/download.php
+++ b/resources/php/download.php
@@ -54,6 +54,7 @@ foreach (StaticHandler::getEnvConfig('filestorages') as $filesystemKey => $files
         ) {
             header("Content-Type: ". File::mimeType($filepath));
             echo file_get_contents($filepath);
+            exit;
         }
     }
 }

--- a/src/Func.php
+++ b/src/Func.php
@@ -89,17 +89,25 @@ final class Func {
         }
 
         foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                if ($preserve_keys == false) {
-                    $value = array_values($value);
+            if ($preserve_keys == false) {
+                if (is_array($value)) {
+                    // NOTE: array_replace is not good (it replaces indexed keys)
+                    $result = array_merge($result, self::arrayFlatten($value, $preserve_keys));
                 }
-
-                // NOTE: array_merge is not good (it doesn't preserve keys)
-                $result = array_replace($result, self::arrayFlatten($value, $preserve_keys));
+                else {
+                    // NOTE: array_replace is not good (it replaces indexed keys)
+                    $result = array_merge($result, array($key => $value));
+                }
             }
             else {
-                // NOTE: array_merge is not good (it doesn't preserve keys)
-                $result = array_replace($result, array($key => $value));
+                if (is_array($value)) {
+                    // NOTE: array_merge is not good (it doesn't preserve keys)
+                    $result = array_replace($result, self::arrayFlatten($value, $preserve_keys));
+                }
+                else {
+                    // NOTE: array_merge is not good (it doesn't preserve keys)
+                    $result = array_replace($result, array($key => $value));
+                }
             }
         }
         return $result;

--- a/src/StaticHandler.php
+++ b/src/StaticHandler.php
@@ -47,10 +47,6 @@ final class StaticHandler
             }
 
             self::$supervisor = in_array(self::$client_ip, Func::arrayFlatten(self::$envConfig->get('development.ips')));
-
-            // var_dump(self::$envConfig->get('development.ips'));
-            // var_dump(self::$supervisor);
-            // die('jere');
         }
 
         set_error_handler(function ($e_code, $text, $file, $line) {


### PR DESCRIPTION
`Func::arrayFlatten()` was losing subarray values, if they had indexed keys.

`resources\php\download.php` didn't exit script, after the file has been returned.