### PR TITLE
Bugfix - Module Filter uses optgroups wrongly

### DIFF
--- a/src/Func.php
+++ b/src/Func.php
@@ -149,6 +149,10 @@ final class Func {
         return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
 
+    static function hasSubarrays (array $array): bool {
+        return count(array_filter(array_keys($array), 'is_array')) > 0;
+    }
+
     static function hasValidJSON (string $file): bool {
         json_decode(file_get_contents($file));
 

--- a/src/Module/HTML/Piece.php
+++ b/src/Module/HTML/Piece.php
@@ -197,7 +197,7 @@ final class Piece {
 
                                         if ($select) {
                                             // optgroups with options
-                                            if (\Arshwell\Monolith\Func::isAssoc($select, false)) {
+                                            if (Func::hasSubarrays($select)) {
                                                 foreach ($select as $optgroup_name => $values) { ?>
                                                     <optgroup label="<?= $optgroup_name ?>">
                                                         <?php
@@ -236,7 +236,7 @@ final class Piece {
                     }
                     else {
                         foreach ($query['filter'] as $key => $values) {
-                            if (!empty($options[$key]) && Func::isAssoc($options[$key], false)) {
+                            if (!empty($options[$key]) && Func::hasSubarrays($options[$key])) {
                                 $options[$key] = Func::arrayFlatten($options[$key], true);
                             }
 


### PR DESCRIPTION
For deciding if a filter selector needs optgroups, it was used `Func::isAssoc()`.

But this method can't see if that options array has subarrays.

So I've created the `Func::hasSubarrays()` method.