### PR TITLE
Filestorage logic added to all File types

### DIFF
--- a/resources/php/download.php
+++ b/resources/php/download.php
@@ -35,12 +35,12 @@ Session::set(StaticHandler::getEnvConfig('web.URL').StaticHandler::getEnvConfig(
 
 $urlpath = ltrim(preg_replace('~^'. StaticHandler::getEnvConfig()->getSiteRoot() .'~', '', URL::path()), '/');
 
-foreach (StaticHandler::getEnvConfig('filestorages') as $filesystemKey => $filesystem) {
-    $filepath = StaticHandler::getEnvConfig()->getFileStoragePath($filesystemKey, 'uploads', false) . $urlpath; // could be outside of project
+foreach (StaticHandler::getEnvConfig('filestorages') as $fileStorageKey => $filestorage) {
+    $filepath = StaticHandler::getEnvConfig()->getFileStoragePath($fileStorageKey, 'uploads', false) . $urlpath; // could be outside of project
 
     if (is_file($filepath) && ($matches = File::parsePath($urlpath))) {
-        if (!empty($filesystem['aliases'])) {
-            foreach ($filesystem['aliases'] as $alias => $myClass) {
+        if (!empty($filestorage['aliases'])) {
+            foreach ($filestorage['aliases'] as $alias => $myClass) {
                 if (Folder::encode($alias) == $matches['class']) {
                     $matches['class'] = Folder::encode($myClass);
                 }
@@ -59,4 +59,5 @@ foreach (StaticHandler::getEnvConfig('filestorages') as $filesystemKey => $files
     }
 }
 
+// in case no file was found
 http_response_code(404);

--- a/src/Env/EnvConfig.php
+++ b/src/Env/EnvConfig.php
@@ -74,7 +74,7 @@ final class EnvConfig
 
     function getFileStoragePath (string $fileStorageKey, string $folder, bool $append_folder = true): string {
         try {
-            return $this->configs["filestorages.$fileStorageKey.paths.$folder"] .'/'. ($append_folder ? "$folder/" : '');
+            return rtrim($this->configs["filestorages.$fileStorageKey.paths.$folder"], '/') .'/'. ($append_folder ? "$folder/" : '');
         }
         catch (\Exception $e) {
             throw new \Exception("|Arshwell| config/filestorages.json should contain [$folder] key, with string value. It represents the optional path to your $folder/ folder, or NULL for default path.");

--- a/src/Table/Files/Doc.php
+++ b/src/Table/Files/Doc.php
@@ -15,14 +15,33 @@ final class Doc implements TableSegment {
     private $folder;
     private $paths = array(); // filepaths
     private $urls = NULL; // if no files in uploads/
+    private $uploadsPath;
 
-    function __construct (string $class, int $id_table = NULL, string $filekey) {
+    function __construct (string $class, int $id_table = NULL, string $filekey, string $fileStorageKey = null) {
         $this->class    = $class;
         $this->id_table = $id_table;
         $this->filekey  = $filekey;
-        $this->folder   = (Folder::encode($class) .'/'. $id_table .'/'. $filekey);
 
-        $files = File::tree(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder, NULL, false, true);
+        if ($fileStorageKey) {
+            // fyi: because the path could be outside of project
+
+            $filestorage = StaticHandler::getEnvConfig("filestorages")[$fileStorageKey];
+
+            if (!empty($filestorage['aliases']) && in_array($class, $filestorage['aliases'])) {
+                // file class becomes the alias class
+                $class = array_search($class, $filestorage['aliases']);
+            }
+
+            $this->uploadsPath = StaticHandler::getEnvConfig()->getFileStoragePath($fileStorageKey, 'uploads');
+        }
+        else {
+            // fyi: the path is in this project
+            $this->uploadsPath = StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads');
+        }
+
+        $this->folder = (Folder::encode($class) .'/'. $id_table .'/'. $filekey);
+
+        $files = File::tree($this->uploadsPath . 'files/'. $this->folder, NULL, false, true);
 
         if ($files) {
             $site = Web::site();
@@ -31,13 +50,13 @@ final class Doc implements TableSegment {
                 if (!isset($files[$language])) {
                     $first_lang = array_key_first($files);
 
-                    if (Folder::copy(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder .'/'. $first_lang, StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder .'/'. $language)) {
+                    if (Folder::copy($this->uploadsPath . 'files/'. $this->folder .'/'. $first_lang, $this->uploadsPath . 'files/'. $this->folder .'/'. $language)) {
                         $files[$language] = $files[$first_lang];
                     }
                 }
 
                 if (!empty($files[$language])) {
-                    $this->paths[$language] = (StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/' . $this->folder .'/'. $language .'/'. array_values($files[$language])[0]);
+                    $this->paths[$language] = ($this->uploadsPath . 'files/' . $this->folder .'/'. $language .'/'. array_values($files[$language])[0]);
 
                     $this->urls[$language] = ($site .'uploads/files/'. $this->folder .'/'. $language .'/'. array_values($files[$language])[0]);
                 }
@@ -80,9 +99,9 @@ final class Doc implements TableSegment {
     function rename (string $name, string $language = NULL): void {
         $language = ($language ?: (($this->class)::TRANSLATOR)::default());
 
-        $file_ext = ('.'. File::extension(File::rFirst(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder .'/'. $language)));
+        $file_ext = ('.'. File::extension(File::rFirst($this->uploadsPath . 'files/'. $this->folder .'/'. $language)));
 
-        foreach (File::rFolder(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder .'/'. $language) as $file) {
+        foreach (File::rFolder($this->uploadsPath . 'files/'. $this->folder .'/'. $language) as $file) {
             rename($file, dirname($file) .'/'. $name . $file_ext);
         }
     }
@@ -90,29 +109,29 @@ final class Doc implements TableSegment {
     function update (array $data, string $language = NULL): void {
         $language = ($language ?: (($this->class)::TRANSLATOR)::default());
 
-        $dirname = StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'.$this->folder.'/'.$language;
+        $dirname = $this->uploadsPath . 'files/'.$this->folder.'/'.$language;
 
         Folder::remove($dirname);
         mkdir($dirname, 0755, true);
 
         if (isset($data['content'])) {
             file_put_contents(
-                StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'.$this->folder.'/'.$language.'/'.$data['name'],
+                $this->uploadsPath . 'files/'.$this->folder.'/'.$language.'/'.$data['name'],
                 $data['content'],
                 LOCK_EX
             );
         }
         else {
-            copy($data['tmp_name'], StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'.$this->folder.'/'.$language.'/'.$data['name']);
+            copy($data['tmp_name'], $this->uploadsPath . 'files/'.$this->folder.'/'.$language.'/'.$data['name']);
         }
 
         $this->urls[$language] = Web::site().'uploads/files/'.$this->folder.'/'.$language.'/'.$data['name'];
     }
 
     function delete (string $language = NULL): bool {
-        Folder::remove(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. $this->folder .'/'. ($language ?? ''));
+        Folder::remove($this->uploadsPath . 'files/'. $this->folder .'/'. ($language ?? ''));
 
-        Folder::removeEmpty(StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads') . 'files/'. dirname($this->folder));
+        Folder::removeEmpty($this->uploadsPath . 'files/'. dirname($this->folder));
 
         if (!$language) {
             $this->urls = NULL;

--- a/src/Table/Files/Image.php
+++ b/src/Table/Files/Image.php
@@ -28,30 +28,29 @@ final class Image implements TableSegment
     private $sizes = array();
     private $uploadsPath;
 
-    function __construct (string $class, int $id_table = NULL, string $filekey, string $filesystemKey = null) {
+    function __construct (string $class, int $id_table = NULL, string $filekey, string $fileStorageKey = null) {
         $this->class    = $class;
         $this->id_table = $id_table;
         $this->filekey  = $filekey;
 
-        foreach (StaticHandler::getEnvConfig('filestorages') as $fsKey => $filesystem) {
-            if (!empty($filesystem['aliases']) && in_array($class, $filesystem['aliases'])) {
-                // file class becomes the alias class
-                $class = array_search($class, $filesystem['aliases']);
-                $filesystemKey = $fsKey;
-                break;
-            }
-        }
-
-        $this->folder = (Folder::encode($class) .'/'. $id_table .'/'. $filekey);
-
-        if ($filesystemKey) {
+        if ($fileStorageKey) {
             // fyi: because the path could be outside of project
-            $this->uploadsPath = StaticHandler::getEnvConfig()->getFileStoragePath($filesystemKey, 'uploads');
+
+            $filestorage = StaticHandler::getEnvConfig("filestorages")[$fileStorageKey];
+
+            if (!empty($filestorage['aliases']) && in_array($class, $filestorage['aliases'])) {
+                // file class becomes the alias class
+                $class = array_search($class, $filestorage['aliases']);
+            }
+
+            $this->uploadsPath = StaticHandler::getEnvConfig()->getFileStoragePath($fileStorageKey, 'uploads');
         }
         else {
             // fyi: the path is in this project
             $this->uploadsPath = StaticHandler::getEnvConfig()->getFileStoragePathByIndex(0, 'uploads');
         }
+
+        $this->folder = (Folder::encode($class) .'/'. $id_table .'/'. $filekey);
 
         $this->config = array_replace_recursive(
             array(

--- a/src/Table/TableFiles.php
+++ b/src/Table/TableFiles.php
@@ -11,23 +11,23 @@ use Arshwell\Monolith\Table;
 final class TableFiles {
     private $files = array(); // has files - images & docs
 
-    function __construct (string $class, int $id_table = NULL) {
+    function __construct (string $class, int $id_table = NULL, string $fileStorageKey = null) {
         foreach (($class)::FILES as $filekey => $info) {
             switch (($info['type'] ?? Table::FILE_IMAGE)) {
                 case Table::FILE_IMAGE: {
-                    $this->files[$filekey] = new Image($class, $id_table, $filekey);
+                    $this->files[$filekey] = new Image($class, $id_table, $filekey, $fileStorageKey);
                     break;
                 }
                 case Table::FILE_IMAGE_GROUP: {
-                    $this->files[$filekey] = new ImageGroup($class, $id_table, $filekey);
+                    $this->files[$filekey] = new ImageGroup($class, $id_table, $filekey, $fileStorageKey);
                     break;
                 }
                 case Table::FILE_DOC: {
-                    $this->files[$filekey] = new Doc($class, $id_table, $filekey);
+                    $this->files[$filekey] = new Doc($class, $id_table, $filekey, $fileStorageKey);
                     break;
                 }
                 case Table::FILE_DOC_GROUP: {
-                    $this->files[$filekey] = new DocGroup($class, $id_table, $filekey);
+                    $this->files[$filekey] = new DocGroup($class, $id_table, $filekey, $fileStorageKey);
                     break;
                 }
             }

--- a/src/Web.php
+++ b/src/Web.php
@@ -431,6 +431,8 @@ final class Web {
                     }
                 }
 
+                $this->warnings = array(Web::WRNNG_NONE);
+
                 $this->prepared = false;
             }
 


### PR DESCRIPTION
All file types now can use different filestorage: Doc, DocGroup, Image, ImageGroup.

`Table::class` contructor has now a 3rd parameter: $fileStorageKey

Typofix: "filesystem" renamed with "filestorage".

Bugfix: `Web::class` fatal error bug if no route found.