### PR TITLE
Keep old files | bin/install-arshwell-example.sh

### DIFF
--- a/bin/install-arshwell-example.sh
+++ b/bin/install-arshwell-example.sh
@@ -1,10 +1,10 @@
 ## Unarchive file: monolith/example.tar.gz in root of project ##
 
 echo "";
-echo "Copying the example in your project ⇩ Good luck!"
+echo "Installing the example in your project ⇩ Good luck!"
 echo "";
 
 BASEDIR=$(dirname $0)
 MONOLITH=$(dirname $BASEDIR) # monolith path
 
-tar --strip-components=1 -C "/" -xf "${MONOLITH}/example.tar.gz"
+tar --strip-components=1 -C "${MONOLITH}/../../../" -xkf "${MONOLITH}/example.tar.gz"


### PR DESCRIPTION
When the webdev user wants to install our Arshwell example, we shouldn't rewrite existing files.

tar `-k` or `--keep-old-files`: Keeps existing files in the destination directory, if a file with the same name already exists.

And target directory fixed.