### PR TITLE
Module - Add triggers on form saving

### DIFF
--- a/bootstrap/download.php
+++ b/bootstrap/download.php
@@ -47,7 +47,7 @@ foreach (StaticHandler::getEnvConfig('filestorages') as $fileStorageKey => $file
         }
 
         if (call_user_func_array(
-                array(Folder::decode($matches['class']), 'fileAccess'),
+                array(Folder::decode($matches['class']), '__fileAccess'),
                 array($matches['id_table'], $matches['filekey'], $matches['language'], $matches['size'], $matches['extension'])
             )
         ) {

--- a/resources/js/module/addon.language.js
+++ b/resources/js/module/addon.language.js
@@ -100,7 +100,10 @@ $(document).ready(function () {
             if (event.offsetX > this.offsetWidth) { // ::after was clicked
                 var container = $(this).closest('[data-lg][data-key]');
 
-                $(this).closest('.card').find('.card-body [data-lg="'+ container.data('lg') +'"][data-key="'+ container.data('key') +'"]').fadeOut(0);
+                $(this).closest('.card')
+                    .find('.card-body [data-lg="'+ container.data('lg') +'"][data-key="'+ container.data('key') +'"]')
+                    .fadeOut(0)
+                ;
 
                 var lg = (
                     $(container).next('[data-lg][data-key]:not([data-lg=""]):not([data-lg="'+ container.data('lg') +'"])').length
@@ -112,9 +115,12 @@ $(document).ready(function () {
 
                 $(this).css('pointer-events', 'none');
 
-                $(this).closest('.card').find('.card-body [data-lg="'+ lg +'"][data-key="'+ container.data('key') +'"]').fadeIn(350, function () {
-                    $(this).find('[language]').css('pointer-events', 'auto');
-                });
+                $(this).closest('.card')
+                    .find('.card-body [data-lg="'+ lg +'"][data-key="'+ container.data('key') +'"]')
+                    .fadeIn(350, function () {
+                        $(this).find('[language]').css('pointer-events', 'auto');
+                    })
+                ;
             }
         });
     })();

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -5,8 +5,11 @@ namespace Arshwell\Monolith;
 use Arshwell\Monolith\Folder;
 use Arshwell\Monolith\File;
 use Exception;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
-final class Cache {
+final class Cache
+{
     static private $project = NULL; // Arshwell project
     static private $folder = 'caches/';
 
@@ -86,6 +89,21 @@ final class Cache {
 
             return true;
         }
+    }
+
+    static function deleteByKeyword(string $word): bool
+    {
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(Folder::root() . self::$folder));
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && strpos($file->getFilename(), $word) !== false) {
+                if (unlink($file->getPathname()) == false) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     static function file (string $key, bool $basename = false): string {

--- a/src/Module/HTML/Field.php
+++ b/src/Module/HTML/Field.php
@@ -1006,7 +1006,7 @@ final class Field {
 
         ob_start(); ?>
 
-            <div <?= ($language ? 'language="'.$language.'"' : '') ?> class="custom-control custom-checkbox d-flex pl-0 my-2">
+            <div <?= ($language ? 'language="'.$language.'"' : '') ?> class="custom-control custom-checkbox d-flex mt-1 mb-2">
                 <input
                 type="checkbox"
                 class="custom-control-input"

--- a/src/Module/Request/Backend/Feature/Update.php
+++ b/src/Module/Request/Backend/Feature/Update.php
@@ -203,8 +203,16 @@ final class Update {
                                     function ($key, $input) use ($back, $field) {
                                         $array = array();
 
+                                        if (empty($field['PHP']['shouldBeSaved'])) {
+                                            $field['PHP']['shouldBeSaved'] = function ($value, $lg) {
+                                                return true;
+                                            };
+                                        }
+
                                         foreach ((($back['DB']['table'])::TRANSLATOR)::LANGUAGES as $lg) {
-                                            $array[$lg] = ($field['PHP']['rules']['update'] ?? $field['PHP']['rules']);
+                                            if ($field['PHP']['shouldBeSaved']($input[$lg] ?? null, $lg)) {
+                                                $array[$lg] = ($field['PHP']['rules']['update'] ?? $field['PHP']['rules']);
+                                            }
                                         }
 
                                         return $array;
@@ -212,7 +220,15 @@ final class Update {
                                 );
                             }
                             else { // is not translated
-                                $array[$key] = ($field['PHP']['rules']['update'] ?? $field['PHP']['rules']);
+                                if (empty($field['PHP']['shouldBeSaved'])) {
+                                    $field['PHP']['shouldBeSaved'] = function ($value) {
+                                        return true;
+                                    };
+                                }
+
+                                if ($field['PHP']['shouldBeSaved']($value[$key] ?? null)) {
+                                    $array[$key] = ($field['PHP']['rules']['update'] ?? $field['PHP']['rules']);
+                                }
                             }
                         }
                     }

--- a/src/Module/Request/Frontend/Action/Insert.php
+++ b/src/Module/Request/Frontend/Action/Insert.php
@@ -43,7 +43,9 @@ final class Insert {
                         	<div class="card-body pt-2 pb-0">
                                 <?= Piece::fields(
                                     $module['back']['DB']['table'],
-                                    $front['fields'],
+                                    array_filter($front['fields'], function (array $filter) {
+                                        return !($filter['LAYOUT']['isSavingOption'] ?? false);
+                                    }),
                                     $module['response']['data'],
                                     call_user_func(function () use ($module) { // translated fields in form (columns & images)
                                         $files = array();
@@ -83,6 +85,9 @@ final class Insert {
                                         );
                                     }
                                 )),
+                                array_filter($front['fields'], function (array $filter) {
+                                    return $filter['LAYOUT']['isSavingOption'] ?? false;
+                                }),
                                 true
                             ) ?>
                     </div>

--- a/src/Module/Request/Frontend/Action/Select.php
+++ b/src/Module/Request/Frontend/Action/Select.php
@@ -44,7 +44,12 @@ final class Select {
                     <div class="col order-2 col-sm-3 col-lg-auto card">
                         <div class="card-body text-right py-3">
                             <?= Piece::columns(
-                                    array_diff_key($front['fields'], array_flip($module['back']['actions']['select']['columns']['private'] ?? array())),
+                                    array_filter(
+                                        array_diff_key($front['fields'], array_flip($module['back']['actions']['select']['columns']['private'] ?? array())),
+                                        function (array $filter) {
+                                            return !($filter['LAYOUT']['isSavingOption'] ?? false);
+                                        }
+                                    ),
                                     $module['query']['columns'] ?? array()
                                 ) ?>
                         </div>

--- a/src/Module/Request/Frontend/Feature/Update.php
+++ b/src/Module/Request/Frontend/Feature/Update.php
@@ -46,7 +46,9 @@ final class Update {
                             	<div class="card-body pt-2 pb-0">
                                     <?= Piece::fields(
                                         $module['back']['DB']['table'],
-                                        $front['fields'],
+                                        array_filter($front['fields'], function (array $filter) {
+                                            return !($filter['LAYOUT']['isSavingOption'] ?? false);
+                                        }),
                                         $module['response']['data'],
                                         call_user_func(function () use ($module) { // translated fields in form (columns & images)
                                             $files = array();
@@ -85,7 +87,10 @@ final class Update {
                                                 (is_callable($array['response']['access']) && call_user_func_array($array['response']['access'], (new \ReflectionFunction($array['response']['access']))->getParameters() ? array($module['query']['id']) : array()) == true)
                                             );
                                         }
-                                    ))
+                                    )),
+                                    array_filter($front['fields'], function (array $filter) {
+                                        return $filter['LAYOUT']['isSavingOption'] ?? false;
+                                    })
                                 ) ?>
                         </div>
                     </div>

--- a/src/Module/Syntax/Frontend/Field/HTML.php
+++ b/src/Module/Syntax/Frontend/Field/HTML.php
@@ -2,12 +2,8 @@
 
 namespace Arshwell\Monolith\Module\Syntax\Frontend\Field;
 
-final class HTML {
-
-    static function wrappers (array $classes): array {
-        return $classes;
-    }
-
+final class HTML
+{
     /**
      * (array|string) $notes
     */

--- a/src/Module/Syntax/Frontend/Field/JS.php
+++ b/src/Module/Syntax/Frontend/Field/JS.php
@@ -2,8 +2,8 @@
 
 namespace Arshwell\Monolith\Module\Syntax\Frontend\Field;
 
-class JS {
-
+class JS
+{
     public static function AJAX (bool $AJAX): bool {
         return $AJAX;
     }

--- a/src/Module/Syntax/Frontend/Field/LAYOUT.php
+++ b/src/Module/Syntax/Frontend/Field/LAYOUT.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Arshwell\Monolith\Module\Syntax\Frontend\Field;
+
+final class LAYOUT
+{
+    static function rowColumns (array $rowColumns): array
+    {
+        return $rowColumns;
+    }
+
+    static function isSavingOption (bool $isSavingOption): bool
+    {
+        return $isSavingOption;
+    }
+}


### PR DESCRIPTION
Include "LAYOUT" option in `front.module.php`.
Replace "HTML.wrappers" with "LAYOUT.rowColumns".

In Table class, add default empty methods triggered before/after DML queries (Data Manipulation Language).