### PR TITLE
Bugfix: CMS - Filter by one2many field not working

### DIFF
--- a/src/Module/HTML/Piece.php
+++ b/src/Module/HTML/Piece.php
@@ -520,11 +520,12 @@ final class Piece {
                                                         break;
                                                     }
                                                     case 'select': {
-                                                        if (!empty($HTML['multiple'])) {
-                                                            echo implode(', ', $value);
-                                                        }
-                                                        else {
-                                                            echo ($HTML['values'][$value] ?? $value);
+                                                            if ($value) {
+                                                                if (!empty($HTML['multiple'])) {
+                                                                    echo implode(', ', $value);
+                                                                } else {
+                                                                    echo ($HTML['values'][$value] ?? $value);
+                                                                }
                                                         }
                                                         break;
                                                     }

--- a/src/Module/Request/Backend/Feature/Update.php
+++ b/src/Module/Request/Backend/Feature/Update.php
@@ -48,7 +48,9 @@ final class Update {
                                     ($back['DB']['table'])::PRIMARY_KEY .' = '. $query['id']
                                 );
 
-                                $response['data'][$key] = new TableColumn($class, $field['DB']['column'] .' IN ('. implode(', ', $ids) .')', $column);
+                                if ($ids) {
+                                    $response['data'][$key] = new TableColumn($class, $field['DB']['column'] . ' IN (' . implode(', ', $ids) . ')', $column);
+                                }
                             }
                         }
                         else {


### PR DESCRIPTION
The where clause query in Select.php didn't took into consideration if filtering by a field which represents a one2many column.