### PR TITLE
Bugfix: TableColumn missing key

### DIFF
--- a/src/Table/TableColumn.php
+++ b/src/Table/TableColumn.php
@@ -43,7 +43,7 @@ final class TableColumn implements TableSegment {
                 }
             }
             else {
-                $input = array_column(DB::select(array(
+                $input[$key] = array_column(DB::select(array(
                     'class'     => $class,
                     'columns'   => ($class)::PRIMARY_KEY .','. $key,
                     'where'     => $where


### PR DESCRIPTION
There is one edge case scenario for which the values weren't included inside the provided key.