### PR TITLE
Fixed DB table prefixing in columns

### DIFF
--- a/src/DB.php
+++ b/src/DB.php
@@ -195,7 +195,8 @@ final class DB
     {
         $dbConnKey = (defined("{$sql['class']}::DB_CONN_KEY") ? ($sql['class'])::DB_CONN_KEY : self::$defaultDbConnKey);
 
-        $sql['columns'] = self::prefix(self::$tb_prefixes[$dbConnKey], $sql['columns']);
+        // dml_dql = true, because there could be subqueries as well
+        $sql['columns'] = self::prefix(self::$tb_prefixes[$dbConnKey], $sql['columns'], true);
 
         $query = "SELECT " . $sql['columns'] . " FROM " . self::$tb_prefixes[$dbConnKey] . ($sql['class'])::TABLE;
 
@@ -349,7 +350,8 @@ final class DB
             $sql['columns'] = $sql['columns'] . ', ' . $sql['sort'];
         }
 
-        $sql['columns'] = self::prefix(self::$tb_prefixes[$dbConnKey], $sql['columns']);
+        // dml_dql = true, because there could be subqueries as well
+        $sql['columns'] = self::prefix(self::$tb_prefixes[$dbConnKey], $sql['columns'], true);
 
         $query = "SELECT " . $sql['columns'] . " FROM " . self::$tb_prefixes[$dbConnKey] . ($sql['class'])::TABLE;
 

--- a/src/Layout.php
+++ b/src/Layout.php
@@ -18,7 +18,7 @@ use ScssPhp\ScssPhp\Compiler as ScssPhp;
  * Class for compiling scss/js, getting utils and links.
 
  * @package https://github.com/arshwell/monolith
-*/
+ */
 final class Layout {
     private static $css_suffixes = array(''); // ex: for certain users
 
@@ -960,14 +960,19 @@ final class Layout {
                     $js_web_class = $js_minifier->minify();
                 }
 
-                file_put_contents(
-                    $jsHeader,
+            $absoluteJsHeader = getcwd() . '/' . $jsHeader;
+
+            if (!file_exists($absoluteJsHeader)) {
+                touch($absoluteJsHeader);
+            }
+
+            file_put_contents(
+                $absoluteJsHeader,
                     self::signature($url).PHP_EOL. $js_web_class .PHP_EOL. implode(';'.PHP_EOL.PHP_EOL, array_map(function (array $file): string {
                         $js_minifier = new JsMin($file['name']);
 
                         return $js_minifier->minify();
-                    }, $files)) .PHP_EOL.self::signature($url),
-                    LOCK_EX
+                }, $files)) . PHP_EOL . self::signature($url)
                 );
 
                 $return = true;
@@ -1050,14 +1055,19 @@ final class Layout {
 
                 ini_set('max_execution_time', ini_get('max_execution_time') + 1);
 
-                file_put_contents(
-                    $jsFooter,
+            $absoluteJsFooter = getcwd() . '/' . $jsFooter;
+
+            if (!file_exists($absoluteJsFooter)) {
+                touch($absoluteJsFooter);
+            }
+
+            file_put_contents(
+                $absoluteJsFooter,
                     self::signature().PHP_EOL. implode(';'.PHP_EOL.PHP_EOL, array_map(function ($file) {
                         $js_minifier = new JsMin($file['name']);
 
                         return $js_minifier->minify();
-                    }, $files)) .PHP_EOL.self::signature(),
-                    LOCK_EX
+                }, $files)) . PHP_EOL . self::signature()
                 );
 
                 $return = true;


### PR DESCRIPTION
- Added third parameter to DB::prefix() method calls for proper column prefixing;
- In Layout, removed LOCK_EX flag from file_put_contents calls for better compatibility;